### PR TITLE
Adds extra encoding for html characters for inline tooltips, parses tooltip contents

### DIFF
--- a/lib/SimpleTooltip.js
+++ b/lib/SimpleTooltip.js
@@ -9,6 +9,16 @@
 
     'use strict';
 
+    /**
+    * Decodes html-encoded string
+    */
+    function htmlDecode(input){
+      var e = document.createElement('textarea');
+      e.innerHTML = input;
+      // handle case of empty input
+      return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+    }
+
     /** @type {Object} namespace */
     mw.libs.SimpleTooltip = {};
 
@@ -50,6 +60,7 @@
         // and set the tooltip text manually
         $context.each(function() {
           var text = $(this).attr('data-simple-tooltip');
+          text = htmlDecode( text );
           options.content = $('<span>' + text + '</span>');
           $(this).tooltipster(options);
         });

--- a/modules/SimpleTooltipParserFunction.php
+++ b/modules/SimpleTooltipParserFunction.php
@@ -25,8 +25,14 @@ class SimpleTooltipParserFunction {
         // BUILD HTML                           //
         //////////////////////////////////////////
 
+		$content = Sanitizer::removeHTMLtags( $title );
+		$content = $parser->recursiveTagParseFully( $content );
+		$content = str_replace('"', "'", $content);
+		$content = trim( $content );
+		$content = htmlspecialchars( $content );
+
         $html  = '<span class="simple-tooltip simple-tooltip-inline"';
-        $html .= ' data-simple-tooltip="' . htmlspecialchars(Sanitizer::removeHTMLtags($title)) . '"';
+        $html .= ' data-simple-tooltip="' . $content . '"';
         $html .= '>' . htmlspecialchars($value) . '</span>';
 
         return array(


### PR DESCRIPTION
We are using SimpleTooltip with https://github.com/wikimedia/mediawiki-extensions-LabeledSectionTransclusion to show tooltips for glossary terms and include glossary terms definitions as tooltip contents. Plus we use VisualEditor and such combination lead to rendering issues in VisualEditor due to extra markup not being encoded and hence not being properly escaped in VE. The patch ensures contents in data attribute are encoded and decoded properly.