### PR TITLE
Fix links to Tooltipster

### DIFF
--- a/README-source.adoc
+++ b/README-source.adoc
@@ -14,7 +14,7 @@ include::docs/gesinn-it-docs-master-pub/general/semver.adoc[]
 include::docs/gesinn-it-docs-master-pub/contributing/contributing.adoc[]
 
 == Attribution
-Uses the http://iamceege.github.io/tooltipster/[Tooltipster Library] and https://github.com/yusukekamiyamane/fugue-icons[Fugue Icons]
+Uses the https://calebjacob.github.io/tooltipster/[Tooltipster Library] and https://github.com/yusukekamiyamane/fugue-icons[Fugue Icons]
 
 ---
 This extension is part of https://semantic.wiki/core[*semantic::core*] - Enterprise Class MediaWiki distribution.

--- a/README.adoc
+++ b/README.adoc
@@ -109,7 +109,7 @@ git push origin feature/your-feature-name
 ====
 
 == Attribution
-Uses the http://iamceege.github.io/tooltipster/[Tooltipster Library] and https://github.com/yusukekamiyamane/fugue-icons[Fugue Icons]
+Uses the https://calebjacob.github.io/tooltipster/[Tooltipster Library] and https://github.com/yusukekamiyamane/fugue-icons[Fugue Icons]
 
 ---
 This extension is part of https://semantic.wiki/core[*semantic::core*] - Enterprise Class MediaWiki distribution.

--- a/lib/SimpleTooltip.js
+++ b/lib/SimpleTooltip.js
@@ -26,7 +26,7 @@
     /**
      * Default Tooltip Options
      *
-     * @see http://iamceege.github.io/tooltipster/
+     * @see https://calebjacob.github.io/tooltipster/
      */
     mw.libs.SimpleTooltip.defaultOptions = {
        animation: 'fade',

--- a/lib/Tooltipster - The jQuery Tooltip Plugin.url
+++ b/lib/Tooltipster - The jQuery Tooltip Plugin.url
@@ -1,2 +1,2 @@
 [InternetShortcut]
-URL=http://iamceege.github.io/tooltipster/
+URL=https://calebjacob.github.io/tooltipster/

--- a/lib/jquery.tooltipster.js
+++ b/lib/jquery.tooltipster.js
@@ -46,7 +46,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 			positionTracker: false,
 			positionTrackerCallback: function(origin){
 				// the default tracker callback will close the tooltip when the trigger is
-				// 'hover' (see https://github.com/iamceege/tooltipster/pull/253)
+				// 'hover' (see https://github.com/calebjacob/tooltipster/pull/253)
 				if(this.option('trigger') == 'hover' && this.option('autoClose')) {
 					this.hide();
 				}


### PR DESCRIPTION
The Tooltipster repository moved, and the website moved without a redirect, after @iamceege changed their name to @calebjacob: calebjacob/tooltipster#806.