### PR TITLE
Issue 13 - fix tooltip parser breaking numbered lists

### DIFF
--- a/src/SimpleTooltipHooks.php
+++ b/src/SimpleTooltipHooks.php
@@ -45,7 +45,7 @@ class SimpleTooltipHooks {
 		}
 
 		$content = Sanitizer::removeSomeTags( $title );
-		$content = $parser->recursiveTagParseFully( $content );
+		$content = $parser->recursiveTagParse( $content );
 		$content = str_replace( '"', "'", $content );
 		$content = trim( $content );
 		$content = htmlspecialchars( $content );

--- a/tests/phpunit/Unit/SimpleTooltipHooksTest.php
+++ b/tests/phpunit/Unit/SimpleTooltipHooksTest.php
@@ -30,9 +30,9 @@ class SimpleTooltipHooksTest extends TestCase {
 							->disableOriginalConstructor()
 							->getMock();
 
-		// Set up the mock behavior for recursiveTagParseFully
+		// Set up the mock behavior for recursiveTagParse
 		$parserMock->expects( $this->once() )
-					->method( 'recursiveTagParseFully' )
+					->method( 'recursiveTagParse' )
 					->willReturn( 'Tooltip content' );
 
 		// Call the inlineTooltip method with some test values


### PR DESCRIPTION
This PR is related to the issue #13. 

This PR contains:

- A fix replacing `recursiveTagParseFully()` with `recursiveTagParse()` in the SimpleTooltip parser function to prevent unwanted `<p> ` tags breaking numbered lists.
- Updates to unit tests to mock the correct parser method (recursiveTagParse), ensuring tooltip content is properly tested and assertions pass.
- Improved inline tooltip rendering inside lists without disrupting MediaWiki's parsing behavior.